### PR TITLE
added react error boundary

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import Providers from "@/modules/common/providers";
+import ErrorBoundary from "@/modules/common/components/ErrorBoundary";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -18,7 +19,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <Providers>{children}</Providers>
+        <ErrorBoundary>
+          <Providers>{children}</Providers>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/modules/common/components/ErrorBoundary/index.tsx
+++ b/modules/common/components/ErrorBoundary/index.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React, { Component, ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+  };
+
+  public static getDerivedStateFromError(_: Error): State {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return <h1>Sorry.. there was an error try to refresh</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
#### Ticket Number: {ticket number}

## Description

We need to add an error boundary so whenever any frontend uncatched error than user so not have blank scren

## Purpose

Whenever uncatched error occur user do not have blank screen rather fallback
## Feature / Fix / Enhancement

-Added react error boundary

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## checks

- [ ] Tested locally with unit tests
- [x] Code compiles correctly

## Screenshot (if any)

N/A
